### PR TITLE
Support Kick messages

### DIFF
--- a/src/effects/clear.ts
+++ b/src/effects/clear.ts
@@ -4,7 +4,10 @@ import { logger } from '../main';
 import { getServer } from '../server/manage';
 
 const clearChatEffectTriggers: Effects.TriggersObject = {};
-clearChatEffectTriggers["event"] = ["twitch:chat-cleared"];
+clearChatEffectTriggers["event"] = [
+    "mage-kick-integration:chat-cleared",
+    "twitch:chat-cleared"
+];
 
 type clearChatEffectParams = {
     routeKey: string;

--- a/src/effects/delete-by-user.ts
+++ b/src/effects/delete-by-user.ts
@@ -4,7 +4,12 @@ import { getServer } from '../server/manage';
 import { Effects } from '@crowbartools/firebot-custom-scripts-types/types/effects';
 
 const deleteByUserEffectTriggers: Effects.TriggersObject = {};
-deleteByUserEffectTriggers["event"] = ["twitch:banned", "twitch:timeout"];
+deleteByUserEffectTriggers["event"] = [
+    "mage-kick-integration:banned",
+    "mage-kick-integration:timeout",
+    "twitch:banned",
+    "twitch:timeout"
+];
 
 type deleteByUserEffectParams = {
     routeKey: string;

--- a/src/effects/delete.ts
+++ b/src/effects/delete.ts
@@ -4,7 +4,10 @@ import { logger } from '../main';
 import { getServer } from '../server/manage';
 
 const deleteChatMessageEffectTriggers: Effects.TriggersObject = {};
-deleteChatMessageEffectTriggers["event"] = ["twitch:chat-message-deleted"];
+deleteChatMessageEffectTriggers["event"] = [
+    "mage-kick-integration:chat-message-deleted",
+    "twitch:chat-message-deleted"
+];
 
 type chatMessageDeletedMetadata = {
     username: string;

--- a/src/effects/display.ts
+++ b/src/effects/display.ts
@@ -8,7 +8,10 @@ import { ChatServerPayload } from '../types/payloads';
 
 const displayChatMessageEffectTriggers: Effects.TriggersObject = {};
 displayChatMessageEffectTriggers["command"] = true;
-displayChatMessageEffectTriggers["event"] = ["twitch:chat-message"];
+displayChatMessageEffectTriggers["event"] = [
+    "mage-kick-integration:chat-message",
+    "twitch:chat-message"
+];
 displayChatMessageEffectTriggers["manual"] = true;
 
 type displayChatMessageEffectParams = {

--- a/static/chat.js
+++ b/static/chat.js
@@ -308,7 +308,7 @@ function createMessageRow(message) {
 
     // Get profile image for the user (for subscribers, mods, etc.) and a blank
     // image if not available or not applicable.
-    if (message.profilePicUrl) {
+    if (message.profilePicUrl && message.profilePicUrl !== "https://kick.com/favicon.ico") { // Profile images broken on Kick
         const profileImageElementName = `profile-image-${message.userId}`;
         let profileImageElement = document.getElementById(profileImageElementName);
         if (profileImageElement) {


### PR DESCRIPTION
<!-- ATTENTION: Using this pull request template is mandatory. -->

### Description
Adds support for chat message display from my Kick integration: <https://github.com/TheStaticMage/firebot-mage-kick-integration>

### Motivation
<!-- Please describe WHY you are making this change. This may include links to GitHub issues if relevant. -->

### Testing
Tested with my overlays. Posting messages and deleting messages by user were tested. The Kick integration currently does not support events for deleted messages or cleared chat.
